### PR TITLE
Tournament navigation buttons

### DIFF
--- a/data/fnm-championship-2012.json
+++ b/data/fnm-championship-2012.json
@@ -1,4 +1,5 @@
 {
+    "type": "FNM Championship",
     "coverage": "https://magic.wizards.com/en/eventcoverage/gc12#4",
     "date": "August 17, 2012",
     "formats": [

--- a/data/invitational-barcelona-1999.json
+++ b/data/invitational-barcelona-1999.json
@@ -11,7 +11,7 @@
     "id": "invitational-barcelona-1999",
     "location": "Barcelona, Spain",
     "logo": "mtg-yellow.png",
-    "name": "Duelist Invitational",
+    "name": "Duelist Invitational 1999",
     "standings": [
         {
             "name": "Michael Long"

--- a/data/invitational-cape-town-2001.json
+++ b/data/invitational-cape-town-2001.json
@@ -12,7 +12,7 @@
   "id": "invitational-cape-town-2001",
   "location": "Cape Town, South Africa",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2001",
   "standings": [
     {
       "name": "Kai Budde"

--- a/data/invitational-essen-2007.json
+++ b/data/invitational-essen-2007.json
@@ -12,7 +12,7 @@
   "id": "invitational-essen-2007",
   "location": "Essen, Germany",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2007",
   "standings": [
     {
       "name": "Tiago Chan"

--- a/data/invitational-hong-kong-1997.json
+++ b/data/invitational-hong-kong-1997.json
@@ -12,7 +12,7 @@
   "id": "invitational-hong-kong-1997",
   "location": "Hong Kong, Hong Kong",
   "logo": "mtg-yellow.png",
-  "name": "Duelist Invitational",
+  "name": "Duelist Invitational 1997",
   "standings": [
     {
       "name": "Olle Rade"

--- a/data/invitational-kuala-lumpur-2000.json
+++ b/data/invitational-kuala-lumpur-2000.json
@@ -12,7 +12,7 @@
   "id": "invitational-kuala-lumpur-2000",
   "location": "Kuala Lumpur, Malaysia",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2000",
   "standings": [
     {
       "name": "Chris Pikula"

--- a/data/invitational-los-angeles-2004.json
+++ b/data/invitational-los-angeles-2004.json
@@ -13,7 +13,7 @@
   "id": "invitational-los-angeles-2004",
   "location": "Los Angeles, California, United States",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2004",
   "standings": [
     {
       "name": "Robert Maher"

--- a/data/invitational-los-angeles-2005.json
+++ b/data/invitational-los-angeles-2005.json
@@ -12,7 +12,7 @@
   "id": "invitational-los-angeles-2005",
   "location": "Los Angeles, California, United States",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2005",
   "standings": [
     {
       "name": "Terry Soh"

--- a/data/invitational-los-angeles-2006.json
+++ b/data/invitational-los-angeles-2006.json
@@ -12,7 +12,7 @@
   "id": "invitational-los-angeles-2006",
   "location": "Los Angeles, California, United States",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2006",
   "standings": [
     {
       "name": "Antoine Ruel"

--- a/data/invitational-rio-de-janeiro-1998.json
+++ b/data/invitational-rio-de-janeiro-1998.json
@@ -11,7 +11,7 @@
   "id": "invitational-rio-de-janeiro-1998",
   "location": "Rio de Janeiro, Brazil",
   "logo": "mtg-yellow.png",
-  "name": "Duelist Invitational",
+  "name": "Duelist Invitational 1998",
   "standings": [
     {
       "name": "Darwin Kastle"

--- a/data/invitational-seattle-2002.json
+++ b/data/invitational-seattle-2002.json
@@ -11,7 +11,7 @@
   "id": "invitational-seattle-2002",
   "location": "Seattle, Washington, United States",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2002",
   "standings": [
     {
       "name": "Jens Thoren"

--- a/data/invitational-sydney-2000.json
+++ b/data/invitational-sydney-2000.json
@@ -12,7 +12,7 @@
   "id": "invitational-sydney-2000",
   "location": "Sydney, Australia",
   "logo": "mtg-yellow.png",
-  "name": "Magic Invitational",
+  "name": "Magic Invitational 2000",
   "standings": [
     {
       "name": "Jon Finkel"

--- a/data/magic-online-championship-2009.json
+++ b/data/magic-online-championship-2009.json
@@ -10,7 +10,7 @@
     "id": "magic-online-championship-2009",
     "location": "Rome, Italy",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2009 Magic Online Championship",
     "standings": [
         {
             "money": 13000,

--- a/data/magic-online-championship-2010.json
+++ b/data/magic-online-championship-2010.json
@@ -10,7 +10,7 @@
     "id": "magic-online-championship-2010",
     "location": "Chiba, Japan",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2010 Magic Online Championship",
     "standings": [
         {
             "money": 25000,

--- a/data/magic-online-championship-2011.json
+++ b/data/magic-online-championship-2011.json
@@ -10,7 +10,7 @@
     "id": "magic-online-championship-2011",
     "location": "San Francisco, California, United States",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2011 Magic Online Championship",
     "standings": [
         {
             "money": 25000,

--- a/data/magic-online-championship-2012.json
+++ b/data/magic-online-championship-2012.json
@@ -10,7 +10,7 @@
     "id": "magic-online-championship-2012",
     "location": "???",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2012 Magic Online Championship",
     "standings": [
         {
             "money": 25000,

--- a/data/magic-online-championship-2013.json
+++ b/data/magic-online-championship-2013.json
@@ -10,7 +10,7 @@
     "id": "magic-online-championship-2013",
     "location": "???",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2013 Magic Online Championship",
     "standings": [
         {
             "money": 25000,

--- a/data/magic-online-championship-2014.json
+++ b/data/magic-online-championship-2014.json
@@ -11,7 +11,7 @@
     "id": "magic-online-championship-2014",
     "location": "Seattle, Washington, United States",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2014 Magic Online Championship",
     "standings": [
         {
             "money": 25000,

--- a/data/magic-online-championship-2015.json
+++ b/data/magic-online-championship-2015.json
@@ -11,7 +11,7 @@
     "id": "magic-online-championship-2015",
     "location": "Seattle, Washington, United States",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2015 Magic Online Championship",
     "standings": [
         {
             "money": 25000,

--- a/data/magic-online-championship-2016.json
+++ b/data/magic-online-championship-2016.json
@@ -9,7 +9,7 @@
     "id": "magic-online-championship-2016",
     "location": "Seattle, Washington, United States",
     "logo": "mtgo.png",
-    "name": "Magic Online Championship",
+    "name": "2016 Magic Online Championship",
     "standings": [
         {
             "money": 25000,

--- a/data/magic-online-championship-2017.json
+++ b/data/magic-online-championship-2017.json
@@ -1,4 +1,5 @@
 {
+    "type": "Mocs",
     "coverage": "https://magic.wizards.com/en/events/coverage/mtgochamp17",
     "date": "March 2-4, 2018",
     "formats": [
@@ -8,7 +9,7 @@
     "id": "magic-online-championship-2017",
     "location": "Seattle, Washington, United States",
     "logo": "ptlogo.png",
-    "name": "Magic Online Championship",
+    "name": "2017 Magic Online Championship",
     "standings": [
         {
             "money": 40000,

--- a/data/masters-chicago-2000.json
+++ b/data/masters-chicago-2000.json
@@ -8,7 +8,7 @@
     "id": "masters-chicago-2000",
     "location": "Chicago, Illinois, United States",
     "logo": "mtg-yellow.png",
-    "name": "Masters Chicago",
+    "name": "Masters Chicago 2000",
     "standings": [
         {
             "money": 25000,

--- a/data/masters-chicago-2003.json
+++ b/data/masters-chicago-2003.json
@@ -8,7 +8,7 @@
     "id": "masters-chicago-2003",
     "location": "Chicago, Illinois, United States",
     "logo": "mtg-yellow.png",
-    "name": "Masters Chicago",
+    "name": "Masters Chicago 2003",
     "standings": [
         {
             "money": 25000,

--- a/data/players-championship-2012.json
+++ b/data/players-championship-2012.json
@@ -9,7 +9,7 @@
     "id": "players-championship-2012",
     "location": "Seattle, Washington, United States",
     "logo": "worldslogo.png",
-    "name": "Players Championship",
+    "name": "2012 Players Championship",
     "standings": [
         {
             "money": 40000,

--- a/data/pro-tour-grn-2018.json
+++ b/data/pro-tour-grn-2018.json
@@ -10,7 +10,7 @@
     "id": "pro-tour-grn-2018",
     "location": "Atlanta, Georgia, United States",
     "logo": "ptgrn.png",
-    "name": "Pro Tour Guilds of Ravniva",
+    "name": "Pro Tour Guilds of Ravnica",
     "standings":
 [
     {

--- a/data/super-sunday-series-championship-2014.json
+++ b/data/super-sunday-series-championship-2014.json
@@ -9,7 +9,7 @@
     "id": "super-sunday-series-championship-2014",
     "location": "Renton, Washington, United States",
     "logo": "mtg-yellow.png",
-    "name": "Super Sunday Series Championship",
+    "name": "Super Sunday Series Championship 2014",
     "standings": [
         {
             "money": 6000,

--- a/data/super-sunday-series-championship-2015.json
+++ b/data/super-sunday-series-championship-2015.json
@@ -10,7 +10,7 @@
     "id": "super-sunday-series-championship-2015",
     "location": "Renton, Washington, United States",
     "logo": "mtg-yellow.png",
-    "name": "Super Sunday Series Championship",
+    "name": "Super Sunday Series Championship 2015",
     "standings": [
         {
             "money": 6000,

--- a/data/super-sunday-series-championship-2016.json
+++ b/data/super-sunday-series-championship-2016.json
@@ -9,7 +9,7 @@
     "id": "super-sunday-series-championship-2016",
     "location": "Renton, Washington, United States",
     "logo": "mtg-yellow.png",
-    "name": "Super Sunday Series Championship",
+    "name": "Super Sunday Series Championship 2016",
     "standings": [
         {
             "money": 6000,

--- a/data/super-sunday-series-championship-2017.json
+++ b/data/super-sunday-series-championship-2017.json
@@ -9,7 +9,7 @@
     "id": "super-sunday-series-championship-2017",
     "location": "Renton, Washington, United States",
     "logo": "mtg-yellow.png",
-    "name": "Super Sunday Series Championship",
+    "name": "Super Sunday Series Championship 2017",
     "standings": [
         {
             "money": 6000,

--- a/data/team-pro-tour-atlanta-1996.json
+++ b/data/team-pro-tour-atlanta-1996.json
@@ -1,4 +1,5 @@
 {
+    "type": "Pro Tour",
     "_comment": "48 teams competed; other teams unknown",
     "date": "September 13-15, 1996",
     "formats": [

--- a/data/world-championships-1994.json
+++ b/data/world-championships-1994.json
@@ -9,7 +9,7 @@
     "id": "world-championships-1994",
     "location": "Milwaukee, Wisconsin, United States",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "1994 World Championships",
     "standings": [
         {
             "name": "Zak Dolan"

--- a/data/world-championships-1995.json
+++ b/data/world-championships-1995.json
@@ -10,7 +10,7 @@
     "id": "world-championships-1995",
     "location": "Seattle, Washington, United States",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "1995 World Championships",
     "standings": [
         {
             "name": "Alexander Blumke"

--- a/data/world-championships-1996.json
+++ b/data/world-championships-1996.json
@@ -10,7 +10,7 @@
     "id": "world-championships-1996",
     "location": "Seattle, Washington, United States",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "1996 World Championships",
     "standings": [
         {
             "money": 26000,

--- a/data/world-championships-1997.json
+++ b/data/world-championships-1997.json
@@ -9,7 +9,7 @@
     "id": "world-championships-1997",
     "location": "Seattle, Washington, United States",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "1997 World Championships",
     "standings": [
         {
             "money": 34000,

--- a/data/world-championships-1998.json
+++ b/data/world-championships-1998.json
@@ -10,7 +10,7 @@
     "id": "world-championships-1998",
     "location": "Seattle, Washington, United States",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "1998 World Championships",
     "standings": [
         {
             "money": 34000,

--- a/data/world-championships-1999.json
+++ b/data/world-championships-1999.json
@@ -10,7 +10,7 @@
     "id": "world-championships-1999",
     "location": "Yokohama, Japan",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "1999 World Championships",
     "standings": [
         {
             "money": 34000,

--- a/data/world-championships-2000.json
+++ b/data/world-championships-2000.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2000",
     "location": "Brussels, Belgium",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2000 World Championships",
     "standings": [
         {
             "money": 34000,

--- a/data/world-championships-2001.json
+++ b/data/world-championships-2001.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2001",
     "location": "Toronto, Canada",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2001 World Championships",
     "standings": [
         {
             "money": 35000,

--- a/data/world-championships-2002.json
+++ b/data/world-championships-2002.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2002",
     "location": "Sydney, Australia",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2002 World Championships",
     "standings": [
         {
             "money": 35000,

--- a/data/world-championships-2003.json
+++ b/data/world-championships-2003.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2003",
     "location": "Berlin, Germany",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2003 World Championships",
     "standings": [
         {
             "money": 35000,

--- a/data/world-championships-2004.json
+++ b/data/world-championships-2004.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2004",
     "location": "San Francisco, California, United States",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2004 World Championships",
     "standings": [
         {
             "money": 35000,

--- a/data/world-championships-2005.json
+++ b/data/world-championships-2005.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2005",
     "location": "Yokohama, Japan",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2005 World Championships",
     "standings": [
         {
             "money": 35000,

--- a/data/world-championships-2006.json
+++ b/data/world-championships-2006.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2006",
     "location": "Paris, France",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2006 World Championships",
     "standings": [
         {
             "money": 50000,

--- a/data/world-championships-2007.json
+++ b/data/world-championships-2007.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2007",
     "location": "New York, New York, United States",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2007 World Championships",
     "standings": [
         {
             "money": 40000,

--- a/data/world-championships-2008.json
+++ b/data/world-championships-2008.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2008",
     "location": "Memphis, Tennessee, United States",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2008 World Championships",
     "standings": [
         {
             "money": 45000,

--- a/data/world-championships-2009.json
+++ b/data/world-championships-2009.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2009",
     "location": "Rome, Italy",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2009 World Championships",
     "standings": [
         {
             "money": 45000,

--- a/data/world-championships-2010.json
+++ b/data/world-championships-2010.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2010",
     "location": "Chiba, Japan",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2010 World Championships",
     "standings": [
         {
             "money": 45000,

--- a/data/world-championships-2011.json
+++ b/data/world-championships-2011.json
@@ -10,7 +10,7 @@
     "id": "world-championships-2011",
     "location": "San Francisco, California, United States",
     "logo": "ptlogo.png",
-    "name": "World Championships",
+    "name": "2011 World Championships",
     "standings": [
         {
             "money": 45000,

--- a/data/world-championships-2013.json
+++ b/data/world-championships-2013.json
@@ -8,7 +8,7 @@
     "id": "world-championships-2013",
     "location": "Amsterdam, The Netherlands",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "2013 World Championships",
     "standings": [
         {
             "money": 40000,

--- a/data/world-championships-2014.json
+++ b/data/world-championships-2014.json
@@ -9,7 +9,7 @@
     "id": "world-championships-2014",
     "location": "Nice, France",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "2014 World Championships",
     "standings": [
         {
             "money": 50000,

--- a/data/world-championships-2015.json
+++ b/data/world-championships-2015.json
@@ -9,7 +9,7 @@
     "id": "world-championships-2015",
     "location": "Seattle, Washington, United States",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "2015 World Championships",
     "standings": [
         {
             "money": 50000,

--- a/data/world-championships-2016.json
+++ b/data/world-championships-2016.json
@@ -9,7 +9,7 @@
     "id": "world-championships-2016",
     "location": "Seattle, Washington, United States",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "2016 World Championships",
     "standings": [
         {
             "money": 70000,

--- a/data/world-championships-2017.json
+++ b/data/world-championships-2017.json
@@ -9,7 +9,7 @@
     "id": "world-championships-2017",
     "location": "Boston, Massachusetts, United States",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "2017 World Championships",
     "standings": [
         {
             "money": 100000,

--- a/data/world-championships-2018.json
+++ b/data/world-championships-2018.json
@@ -9,7 +9,7 @@
     "id": "world-championships-2018",
     "location": "Las Vegas, Nevada, United States",
     "logo": "worldslogo.png",
-    "name": "World Championships",
+    "name": "2018 World Championships",
     "standings": [
         {
             "money": 100000,

--- a/data/world-championships-teams-1996.json
+++ b/data/world-championships-teams-1996.json
@@ -9,7 +9,7 @@
     "id": "world-championships-teams-1996",
     "location": "Seattle, Washington, United States",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "1996 World Championships - Team Competition",
     "standings": [
         {
             "name": "Dennis Bentley"

--- a/data/world-championships-teams-1997.json
+++ b/data/world-championships-teams-1997.json
@@ -8,7 +8,7 @@
     "id": "world-championships-teams-1997",
     "location": "Seattle, Washington, United States",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "1997 World Championships - Team Competition",
     "standings": [
         {
             "name": "Gary Krakower"

--- a/data/world-championships-teams-1998.json
+++ b/data/world-championships-teams-1998.json
@@ -8,7 +8,7 @@
     "id": "world-championships-teams-1998",
     "location": "Seattle, Washington, United States",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "1998 World Championships - Team Competition",
     "standings": [
         {
             "money": 5500,

--- a/data/world-championships-teams-1999.json
+++ b/data/world-championships-teams-1999.json
@@ -10,7 +10,7 @@
     "id": "world-championships-teams-1999",
     "location": "Yokohama, Japan",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "1999 World Championships - Team Competition",
     "standings": [
         {
             "money": 5500,

--- a/data/world-championships-teams-2000.json
+++ b/data/world-championships-teams-2000.json
@@ -8,7 +8,7 @@
     "id": "world-championships-teams-2000",
     "location": "Brussels, Belgium",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2000 World Championships - Team Competition",
     "standings": [
         {
             "money": 5500,

--- a/data/world-championships-teams-2001.json
+++ b/data/world-championships-teams-2001.json
@@ -8,7 +8,7 @@
     "id": "world-championships-teams-2001",
     "location": "Toronto, Canada",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2001 World Championships - Team Competition",
     "standings": [
         {
             "money": 10000,

--- a/data/world-championships-teams-2002.json
+++ b/data/world-championships-teams-2002.json
@@ -8,7 +8,7 @@
     "id": "world-championships-teams-2002",
     "location": "Sydney, Australia",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2002 World Championships - Team Competition",
     "standings": [
         {
             "money": 10000,

--- a/data/world-championships-teams-2003.json
+++ b/data/world-championships-teams-2003.json
@@ -8,7 +8,7 @@
     "id": "world-championships-teams-2003",
     "location": "Berlin, Germany",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2003 World Championships - Team Competition",
     "standings": [
         {
             "money": 10000,

--- a/data/world-championships-teams-2004.json
+++ b/data/world-championships-teams-2004.json
@@ -8,7 +8,7 @@
     "id": "world-championships-teams-2004",
     "location": "San Francisco, California, United States",
     "logo": "worldslogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2004 World Championships - Team Competition",
     "standings": [
         {
             "money": 10000,

--- a/data/world-championships-teams-2005.json
+++ b/data/world-championships-teams-2005.json
@@ -1,4 +1,5 @@
 {
+    "type": "World Championships",
     "coverage": "http://web.archive.org/web/20051229184925/http://www.wizards.com/default.asp?x=mtgevent/worlds05/welcome",
     "date": "November 30-December 4, 2005",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-championships-teams-2005",
     "location": "Yokohama, Japan",
     "logo": "ptlogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2005 World Championships - Team Competition",
     "standings": [
         {
             "money": 10000,

--- a/data/world-championships-teams-2006.json
+++ b/data/world-championships-teams-2006.json
@@ -1,4 +1,5 @@
 {
+    "type": "World Championships",
     "coverage": "http://web.archive.org/web/20061221045655/http://www.wizards.com/default.asp?x=mtgevent/worlds06/welcome",
     "date": "November 29-December 3, 2006",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-championships-teams-2006",
     "location": "Yokohama, Japan",
     "logo": "ptlogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2006 World Championships - Team Competition",
     "standings": [
         {
             "money": 10000,

--- a/data/world-championships-teams-2007.json
+++ b/data/world-championships-teams-2007.json
@@ -1,4 +1,5 @@
 {
+    "type": "World Championships",
     "coverage": "https://magic.wizards.com/en/events/coverage/2007wc",
     "date": "December 6-9, 2007",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-championships-teams-2007",
     "location": "New York, New York, United States",
     "logo": "ptlogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2007 World Championships - Team Competition",
     "standings": [
         {
             "money": 3000,

--- a/data/world-championships-teams-2008.json
+++ b/data/world-championships-teams-2008.json
@@ -1,4 +1,5 @@
 {
+    "type": "World Championships",
     "coverage": "https://magic.wizards.com/en/events/coverage/wmcq08",
     "date": "December 11-14, 2008",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-championships-teams-2008",
     "location": "Memphis, Tennessee, United States",
     "logo": "ptlogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2008 World Championships - Team Competition",
     "standings": [
         {
             "money": 4000,

--- a/data/world-championships-teams-2009.json
+++ b/data/world-championships-teams-2009.json
@@ -1,4 +1,5 @@
 {
+    "type": "World Championships",
     "coverage": "http://web.archive.org/web/20091212060443/http://www.wizards.com/Magic/Magazine/Article.aspx?x=mtg/daily/eventcoverage/worlds09/welcome",
     "date": "November 19-22, 2009",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-championships-teams-2009",
     "location": "Rome, Italy",
     "logo": "ptlogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2009 World Championships - Team Competition",
     "standings": [
         {
             "money": 4000,

--- a/data/world-championships-teams-2010.json
+++ b/data/world-championships-teams-2010.json
@@ -1,4 +1,5 @@
 {
+    "type": "World Championships",
     "coverage": "http://web.archive.org/web/20101218150225/http://www.wizards.com/magic/magazine/article.aspx?x=mtg/daily/eventcoverage/worlds10/welcome",
     "date": "December 9-12, 2010",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-championships-teams-2010",
     "location": "Chiba, Japan",
     "logo": "ptlogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2010 World Championships - Team Competition",
     "standings": [
         {
             "money": 4000,

--- a/data/world-championships-teams-2011.json
+++ b/data/world-championships-teams-2011.json
@@ -1,4 +1,5 @@
 {
+    "type": "World Championships",
     "coverage": "http://web.archive.org/web/20111125184613/http://www.wizards.com/magic/magazine/article.aspx?x=mtg/daily/eventcoverage/worlds11/welcome",
     "date": "November 17-20, 2011",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-championships-teams-2011",
     "location": "San Francisco, California, United States",
     "logo": "ptlogo.png",
-    "name": "World Championship - Team Competition",
+    "name": "2011 World Championships - Team Competition",
     "standings": [
         {
             "money": 4000,

--- a/data/world-magic-cup-2012.json
+++ b/data/world-magic-cup-2012.json
@@ -1,4 +1,5 @@
 {
+    "type": "WMC",
     "coverage": "https://magic.wizards.com/en/events/coverage/2012wmc",
     "date": "August 17-19, 2012",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-magic-cup-2012",
     "location": "Indianapolis, Indiana, United States",
     "logo": "wmc.png",
-    "name": "World Magic Cup",
+    "name": "World Magic Cup 2012",
     "standings": [
         {
             "money": 10000,

--- a/data/world-magic-cup-2013.json
+++ b/data/world-magic-cup-2013.json
@@ -1,4 +1,5 @@
 {
+    "type": "WMC",
     "coverage": "https://magic.wizards.com/en/events/coverage/levy-du-soleil-en-france",
     "date": "August 2-4, 2013",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-magic-cup-2013",
     "location": "Amsterdam, Netherlands",
     "logo": "wmc.png",
-    "name": "World Magic Cup",
+    "name": "World Magic Cup 2013",
     "standings": [
         {
             "money": 12000,

--- a/data/world-magic-cup-2014.json
+++ b/data/world-magic-cup-2014.json
@@ -1,4 +1,5 @@
 {
+    "type": "WMC",
     "coverage": "https://magic.wizards.com/en/events/coverage/2014WMC",
     "date": "December 5-7, 2014",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-magic-cup-2014",
     "location": "Nice, France",
     "logo": "wmc.png",
-    "name": "World Magic Cup",
+    "name": "World Magic Cup 2014",
     "standings": [
         {
             "money": 12000,

--- a/data/world-magic-cup-2015.json
+++ b/data/world-magic-cup-2015.json
@@ -1,4 +1,5 @@
 {
+    "type": "WMC",
     "coverage": "https://magic.wizards.com/en/events/coverage/2015WMC",
     "date": "December 11-13, 2015",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-magic-cup-2015",
     "location": "Barcelona, Spain",
     "logo": "wmc.png",
-    "name": "World Magic Cup",
+    "name": "World Magic Cup 2015",
     "standings": [
         {
             "money": 12000,

--- a/data/world-magic-cup-2016.json
+++ b/data/world-magic-cup-2016.json
@@ -1,4 +1,5 @@
 {
+    "type": "WMC",
     "coverage": "https://magic.wizards.com/en/events/coverage/2016WMC",
     "date": "November 18-20, 2016",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-magic-cup-2016",
     "location": "Rotterdam, Netherlands",
     "logo": "wmc.png",
-    "name": "World Magic Cup",
+    "name": "World Magic Cup 2016",
     "standings": [
         {
             "money": 12000,

--- a/data/world-magic-cup-2017.json
+++ b/data/world-magic-cup-2017.json
@@ -1,4 +1,5 @@
 {
+    "type": "WMC",
     "coverage": "https://magic.wizards.com/en/events/coverage/2017WMC",
     "date": "December 1-3, 2017",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-magic-cup-2017",
     "location": "Nice, France",
     "logo": "wmc.png",
-    "name": "World Magic Cup",
+    "name": "World Magic Cup 2017",
     "standings": [
         {
             "money": 15000,

--- a/data/world-magic-cup-2018.json
+++ b/data/world-magic-cup-2018.json
@@ -1,4 +1,5 @@
 {
+    "type": "WMC",
     "coverage": "https://magic.wizards.com/en/events/coverage/2018WMC",
     "date": "December 14-16, 2018",
     "formats": [
@@ -7,7 +8,7 @@
     "id": "world-magic-cup-2018",
     "location": "Barcelona, Spain",
     "logo": "wmc.png",
-    "name": "World Magic Cup",
+    "name": "World Magic Cup 2018",
     "standings": [
         {
             "money": 15000,

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,3 +1,8 @@
+.pager {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
 .lead.tournamentLead {
   margin-bottom: 0;
 }

--- a/src/js/Tournament.react.js
+++ b/src/js/Tournament.react.js
@@ -12,12 +12,21 @@ import Players from './Players.js';
 const Tournament = props => {
   const id = props.params.id;
   const t = Tournaments.byID(id);
+  const surrounding = Tournaments.page(t);
+  const prev = surrounding[0];
+  const next = surrounding[1];
   if (!t) {
     return <NotFound />;
   }
   return (
     <div className="col-md-offset-3 col-md-6">
       <DocumentTitle title={t.name} />
+      <nav aria-label="...">
+        <ul className="pager">
+          {prev ? <li className="previous"><a href={"/tournament/" + prev.id}><span aria-hidden="true">&larr;</span> {prev.name}</a></li> : ''}
+          {next ? <li className="next"><a href={"/tournament/" + next.id}>{next.name} <span aria-hidden="true">&rarr;</span></a></li> : ''}
+        </ul>
+      </nav>
       <div className="page-header pageHeader">
         <h1>{t.coverage ? <a href={t.coverage}>{t.name}</a> : t.name}</h1>
         <p className="lead tournamentLead">{t.formats.join(' / ')}</p>

--- a/src/js/Tournaments.js
+++ b/src/js/Tournaments.js
@@ -21,5 +21,16 @@ const byID = id => {
   return null;
 };
 
+const page = tournament => {
+  if (!Tournaments[tournament.id]) {
+    return null;
+  }
+  let filteredTournaments = window.Recent.filter(t => t.type === tournament.type);
+  let tournamentIndex = filteredTournaments.findIndex(t => t.id === tournament.id);
+  let prev = (tournamentIndex < filteredTournaments.length - 1) ? new Tournament(Tournaments[filteredTournaments[tournamentIndex + 1].id]) : null;
+  let next = (tournamentIndex > 0) ? new Tournament(Tournaments[filteredTournaments[tournamentIndex - 1].id]) : null;
+  return [prev, next];
+};
+
 const asArray = () => TournamentsArray;
-export default {asArray, byID};
+export default {asArray, byID, page};


### PR DESCRIPTION
Implements tournament-contextual pagination on tournament pages. Pagination will only show if there is a tournament to navigate to, and will not render at all if it is a unique tournament type (like Silver Showcase).

![pt_pagination](https://user-images.githubusercontent.com/2223876/53780588-169e3780-3ed3-11e9-946f-3e28df132490.PNG)
Pagination on a Pro Tour Page
![other_pagination](https://user-images.githubusercontent.com/2223876/53780589-19009180-3ed3-11e9-9142-e4ce4b037ca1.PNG)
Pagination on a different type of tournament page.